### PR TITLE
Add folder or single markdown upload option

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -200,7 +200,11 @@ export default function Home() {
               <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">
                 .md
               </code>{" "}
-              files to preview them with GitHub-style rendering.
+              files or a single{" "}
+              <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">
+                .md
+              </code>{" "}
+              file to preview with GitHub-style rendering.
             </p>
             <UploadZone onFilesLoaded={handleFilesLoaded} />
             <p className="text-xs text-gray-400 text-center mt-4">

--- a/components/UploadZone.tsx
+++ b/components/UploadZone.tsx
@@ -9,7 +9,8 @@ interface UploadZoneProps {
 }
 
 export default function UploadZone({ onFilesLoaded }: UploadZoneProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const folderInputRef = useRef<HTMLInputElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFiles = async (fileList: FileList) => {
     const mdFiles: { name: string; content: string }[] = [];
@@ -50,11 +51,10 @@ export default function UploadZone({ onFilesLoaded }: UploadZoneProps) {
     <div
       onDrop={handleDrop}
       onDragOver={(e) => e.preventDefault()}
-      onClick={() => inputRef.current?.click()}
       className="cursor-pointer border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-xl p-12 text-center hover:border-blue-500 hover:bg-blue-50 dark:hover:bg-blue-950 transition-colors"
     >
       <input
-        ref={inputRef}
+        ref={folderInputRef}
         type="file"
         // @ts-expect-error – webkitdirectory is non-standard HTML attribute
         webkitdirectory=""
@@ -64,6 +64,17 @@ export default function UploadZone({ onFilesLoaded }: UploadZoneProps) {
         className="hidden"
         onChange={(e) => {
           if (e.target.files) handleFiles(e.target.files);
+          e.currentTarget.value = "";
+        }}
+      />
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".md"
+        className="hidden"
+        onChange={(e) => {
+          if (e.target.files) handleFiles(e.target.files);
+          e.currentTarget.value = "";
         }}
       />
       <div className="flex flex-col items-center gap-3">
@@ -81,11 +92,33 @@ export default function UploadZone({ onFilesLoaded }: UploadZoneProps) {
           />
         </svg>
         <p className="text-lg font-medium text-gray-700 dark:text-gray-300">
-          Drop a folder or click to browse
+          Drop markdown files or choose what to upload
         </p>
         <p className="text-sm text-gray-500 dark:text-gray-400">
-          All <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">.md</code> files inside the folder will be opened as tabs
+          Upload a folder of markdown files or a single <code className="bg-gray-100 dark:bg-gray-800 px-1 rounded">.md</code> file.
         </p>
+        <div className="mt-2 flex flex-wrap items-center justify-center gap-2">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              folderInputRef.current?.click();
+            }}
+            className="px-4 py-2 text-sm font-medium bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+          >
+            Upload Folder
+          </button>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              fileInputRef.current?.click();
+            }}
+            className="px-4 py-2 text-sm font-medium bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 rounded-lg transition-colors"
+          >
+            Upload .md File
+          </button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add explicit upload actions for folder and single .md file
- keep drag-and-drop support for markdown files
- update landing copy to describe both upload options

## Testing
- verified TypeScript diagnostics show no errors in updated files