### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-test-build.yml
+++ b/.github/workflows/ci-test-build.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test-and-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wu21-web/MeReader/security/code-scanning/3](https://github.com/wu21-web/MeReader/security/code-scanning/3)

In general, fix this problem by adding an explicit `permissions` block to the workflow (at the root level or per job) that grants only the minimal required scopes. For a read-only CI workflow that just checks out code and runs Node.js commands, `contents: read` is typically sufficient and aligns with the principle of least privilege.

For this specific workflow in `.github/workflows/ci-test-build.yml`, the best fix without changing functionality is to add a root-level `permissions:` block (so it applies to all current and future jobs unless overridden). Insert it after the `on:` block, granting only `contents: read`. No steps in the provided snippet need write access, and no additional imports or methods are required because this is a YAML configuration file for GitHub Actions.

Concretely:
- Edit `.github/workflows/ci-test-build.yml`.
- After the existing `on:` configuration (after `pull_request:` on line 5), insert:

```yaml
permissions:
  contents: read
```

This keeps the workflow behavior identical while constraining the `GITHUB_TOKEN` to read-only repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
