### PR TITLE
fix: prevent polynomial ReDoS in export title parsing

### DIFF
--- a/app/api/convert-md/route.ts
+++ b/app/api/convert-md/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from "next/server";
 import JSZip from "jszip";
 import { marked } from "marked";
 import sanitizeHtml from "sanitize-html";
-import { escapeHtml } from "@/lib/exportTitle";
 import { deriveExportTitle, escapeHtml, sanitizeFileName } from "@/lib/exportTitle";
 
 export const runtime = "nodejs";


### PR DESCRIPTION
## Summary (i generated it with copilot)
- Replace regex-based title cleanup on user input with deterministic string parsing in export routes
- Remove the pattern flagged by CodeQL ()
- Keep existing behavior for stripping path prefixes and markdown suffixes\n\n## Files changed
-  app/api/export-pdf/route.ts
- app/api/export-png-pages/route.ts
- ## Validation
- 
> mereader@0.1.0 lint
> eslint . app/api/export-pdf/route.ts app/api/export-png-pages/route.ts\n- No TypeScript errors in edited files