### PR TITLE
Migrate Dockerfile from legacy to standard format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN npm prune --omit=dev
 FROM base AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
-ENV PORT 3000
+ENV NODE_ENV=production
+ENV PORT=3000
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libnss3 \


### PR DESCRIPTION
This pull request makes a minor update to the `Dockerfile` to improve environment variable assignment syntax. The change switches from the old `ENV KEY VALUE` format to the more explicit `ENV KEY=VALUE` format for `NODE_ENV` and `PORT`.