### PR TITLE
Upgrade to  pinned npm version in Dockerfile (global)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM base AS deps
 WORKDIR /app
 
 COPY package.json package-lock.json* ./
-RUN npm install npm@12.0.1
+RUN npm install -g npm@12.0.1
 RUN npm ci
 
 FROM base AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM base AS deps
 WORKDIR /app
 
 COPY package.json package-lock.json* ./
+RUN npm install npm@12.0.1
 RUN npm ci
 
 FROM base AS builder


### PR DESCRIPTION
**_Copilot Summary:_**

This pull request makes a small change to the `Dockerfile` to ensure a specific version of npm is used during the dependency installation step.

- Ensures npm version 12.0.1 is installed before running `npm ci` in the `deps` stage of the `Dockerfile` to improve build consistency.