### PR TITLE
bump: mereader to v2.5

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -2,6 +2,12 @@ name: Build and Release Docker Container
 
 on:
     workflow_dispatch:
+    release:
+        types: [published]
+
+permissions:
+    contents: read
+    packages: write
 
 jobs:
     build-and-release:
@@ -16,7 +22,7 @@ jobs:
               with:
                   registry: ghcr.io
                   username: 'wu21-web'
-                  password: ${{ secrets.DOCKER_TOKEN }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
             
             - name: Print additional debug info
               run: |
@@ -33,4 +39,4 @@ jobs:
               with:
                   context: .
                   push: true
-                  tags: ghcr.io/wu21-web/mereader:2.3
+                  tags: ghcr.io/wu21-web/mereader:2.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mereader",
-  "version": "2.3",
+  "version": "2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mereader",
-  "version": "2.3",
+  "version": "2.5",
   "private": false,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
This pull request updates the release process and versioning for the Docker container and the application. The workflow is enhanced to trigger on GitHub Releases, uses a more secure authentication method, and bumps the version to 2.5.

**Workflow improvements:**

* The GitHub Actions workflow in `.github/workflows/docker-release.yml` is now triggered on both manual dispatch and when a release is published, enabling automatic Docker builds and releases upon new GitHub Releases.
* The workflow now uses the built-in `GITHUB_TOKEN` for authentication when pushing Docker images, improving security and reducing the need for custom secrets.

**Version updates:**

* The Docker image tag and the `package.json` version have both been updated from `2.3` to `2.5` to reflect the new release. [[1]](diffhunk://#diff-155353073f96bc01f2db838a9b2a2112568bac7ea32a4b4797c5dbc21c6fca42L36-R42) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)